### PR TITLE
update hero image dimensions and adjust header link comments

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -49,10 +49,10 @@ export default function Home() {
               >
                 <Image
                   src="/trust_hero.svg"
-                  width={650}
-                  height={700}
+                  width={600}
+                  height={600}
                   alt="Trust Protocol"
-                  className="mx-auto drop-shadow-2xl"
+                  className="width-[60%] mx-auto drop-shadow-2xl"
                   priority
                 />
               </motion.div>

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -34,13 +34,13 @@ export default function Header() {
 
           {/* Desktop Navigation */}
           <nav className="hidden lg:flex items-center space-x-4 xl:space-x-6">
-            <Link
+            {/* <Link
               href="/leaderboard"
               className="text-sm xl:text-base font-medium text-primary-foreground hover:underline hover:text-primary transition-colors flex items-center gap-1"
             >
               <Trophy className="w-4 h-4" />
               Leaderboard
-            </Link>
+            </Link> */}
             {[
               { href: "https://www.overleaf.com/read/zyhmdxynwxgt#a050e6", label: "Whitepaper" },
               { href: "https://t.me/+e2_TcJOoNO80MzA9", label: "Telegram" },
@@ -101,14 +101,14 @@ export default function Header() {
           border-l border-white/20 shadow-xl
         `}>
           <div className="flex flex-col gap-2">
-            <Link
+            {/* <Link
               href="/leaderboard"
               className="flex items-center gap-3 p-3 rounded-xl bg-white/20 hover:bg-white/30 transition-all text-primary font-medium"
               onClick={toggleMenu}
             >
               <Trophy className="w-5 h-5" />
               <span className="text-base">Leaderboard</span>
-            </Link>
+            </Link> */}
             {[
               { href: "https://www.overleaf.com/read/zyhmdxynwxgt#a050e6", icon: "📄", label: "Whitepaper" },
               { href: "https://t.me/+e2_TcJOoNO80MzA9", icon: "💬", label: "Telegram" },


### PR DESCRIPTION
This pull request includes changes to the `Home` and `Header` components to adjust image dimensions and temporarily remove the "Leaderboard" link from the navigation.

Changes to `Home` component:

* Adjusted the width and height of the `Image` component and updated the class to use a percentage width. (`app/page.tsx`)

Changes to `Header` component:

* Commented out the "Leaderboard" link in the desktop navigation menu. (`components/layout/header.tsx`)
* Commented out the "Leaderboard" link in the mobile navigation menu. (`components/layout/header.tsx`)