### PR TITLE
update whitepaper link to Google Drive

### DIFF
--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -42,7 +42,7 @@ export default function Header() {
               Leaderboard
             </Link> */}
             {[
-              { href: "https://www.overleaf.com/read/zyhmdxynwxgt#a050e6", label: "Whitepaper" },
+              { href: "https://drive.google.com/file/d/1M1AUNLmCvXPADI_5Ld7QKYN2WImuDJWJ/view?usp=sharing", label: "Whitepaper" },
               { href: "https://t.me/+e2_TcJOoNO80MzA9", label: "Telegram" },
               { href: "https://x.com/_trustprotocol", label: "Twitter" },
               { href: "https://github.com/the-trustprotocol", label: "Github" }


### PR DESCRIPTION
This pull request includes a small change to the `components/layout/header.tsx` file. The change updates the URL for the "Whitepaper" link in the header component.

* [`components/layout/header.tsx`](diffhunk://#diff-30fd0c9da72104356821996b967545b25fb6009cb59051ee831eb7a74bae5d8cL45-R45): Updated the "Whitepaper" link to a new URL on Google Drive.